### PR TITLE
feat: add trace aggregation API

### DIFF
--- a/ingestBackend/README.md
+++ b/ingestBackend/README.md
@@ -1,0 +1,68 @@
+# Ingest Backend
+
+This service provides APIs for working with ingested request data. It now stores
+traces in a dedicated MongoDB collection that references the `requests`
+collection, enabling more targeted queries and aggregations.
+
+## Collections
+
+- **requests** – stores metadata about each request including the session it
+  belongs to, its key, duration (in milliseconds) and status.
+- **traces** – stores trace payloads for each request. Each trace document
+  references the request it belongs to through the `requestId` field and keeps
+  all spans for that trace.
+
+## API
+
+### `GET /sessions/:sessionId/traces`
+
+Returns traces for the supplied session grouped by the request key. For each
+request key the response includes the associated request metadata (`key`,
+`durMs` and `status`) along with every trace recorded for that request.
+
+```json
+{
+  "sessionId": "session-123",
+  "groups": [
+    {
+      "key": "request.key",
+      "request": {
+        "key": "request.key",
+        "durMs": 120,
+        "status": 200
+      },
+      "traces": [
+        {
+          "id": "66a...",
+          "traceId": "trace-1",
+          "spans": [
+            {
+              "spanId": "span-1",
+              "name": "root",
+              "startTime": "2024-01-01T00:00:00.000Z",
+              "durationMs": 12,
+              "attributes": {}
+            }
+          ],
+          "createdAt": "2024-01-01T00:00:00.000Z",
+          "updatedAt": "2024-01-01T00:00:00.000Z"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Running the service
+
+Set the `MONGO_URI` environment variable so the service can connect to MongoDB
+and then start the server:
+
+```bash
+cd ingestBackend
+npm install
+npm start
+```
+
+By default the server listens on port `3000`. Use the `PORT` environment
+variable to choose a different port.

--- a/ingestBackend/package.json
+++ b/ingestBackend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ingest-backend",
+  "version": "1.0.0",
+  "description": "Ingestion backend service for managing requests and traces.",
+  "main": "src/app.js",
+  "scripts": {
+    "start": "node src/app.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "mongoose": "^8.4.0"
+  }
+}

--- a/ingestBackend/src/app.js
+++ b/ingestBackend/src/app.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const { connect } = require('./db/connection');
+const traceRoutes = require('./routes/traces');
+
+const app = express();
+app.use(express.json());
+app.use(traceRoutes);
+
+// eslint-disable-next-line no-console
+function logError(error) {
+  // Centralise logging without adding an entire logging framework.
+  console.error('[ingest-backend] error', error); // eslint-disable-line no-console
+}
+
+// Simple error handler to make debugging easier for the API consumer.
+// eslint-disable-next-line no-unused-vars
+app.use((error, _req, res, _next) => {
+  logError(error);
+  res.status(500).json({
+    error: 'Internal Server Error',
+    message: error.message,
+  });
+});
+
+async function start(port = process.env.PORT || 3000) {
+  await connect();
+  return new Promise((resolve) => {
+    const server = app.listen(port, () => {
+      // eslint-disable-next-line no-console
+      console.log(`Ingest backend listening on port ${port}`);
+      resolve(server);
+    });
+  });
+}
+
+module.exports = {
+  app,
+  start,
+};
+
+if (require.main === module) {
+  start().catch((error) => {
+    // eslint-disable-next-line no-console
+    console.error('Failed to start ingest backend', error);
+    process.exit(1);
+  });
+}

--- a/ingestBackend/src/db/connection.js
+++ b/ingestBackend/src/db/connection.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+
+let connectionPromise;
+
+async function connect(connectionString = process.env.MONGO_URI) {
+  if (!connectionString) {
+    throw new Error('Missing MongoDB connection string. Set the MONGO_URI environment variable.');
+  }
+
+  if (!connectionPromise) {
+    connectionPromise = mongoose.connect(connectionString, {
+      serverSelectionTimeoutMS: 5000,
+    });
+  }
+
+  return connectionPromise;
+}
+
+module.exports = {
+  connect,
+  mongoose,
+};

--- a/ingestBackend/src/models/request.js
+++ b/ingestBackend/src/models/request.js
@@ -1,0 +1,36 @@
+const { Schema, model, models } = require('mongoose');
+
+const RequestSchema = new Schema(
+  {
+    sessionId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    key: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    durMs: {
+      type: Number,
+      default: null,
+    },
+    status: {
+      type: Number,
+      default: null,
+    },
+    metadata: {
+      type: Schema.Types.Mixed,
+      default: {},
+    },
+  },
+  {
+    collection: 'requests',
+    timestamps: true,
+  }
+);
+
+RequestSchema.index({ sessionId: 1, key: 1 });
+
+module.exports = models.Request || model('Request', RequestSchema);

--- a/ingestBackend/src/models/trace.js
+++ b/ingestBackend/src/models/trace.js
@@ -1,0 +1,61 @@
+const { Schema, model, models } = require('mongoose');
+
+const TraceSpanSchema = new Schema(
+  {
+    spanId: {
+      type: String,
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+    },
+    startTime: {
+      type: Date,
+      required: true,
+    },
+    durationMs: {
+      type: Number,
+      required: true,
+    },
+    attributes: {
+      type: Schema.Types.Mixed,
+      default: {},
+    },
+  },
+  { _id: false }
+);
+
+const TraceSchema = new Schema(
+  {
+    sessionId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    requestId: {
+      type: Schema.Types.ObjectId,
+      ref: 'Request',
+      required: true,
+      index: true,
+    },
+    traceId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    spans: {
+      type: [TraceSpanSchema],
+      default: [],
+    },
+  },
+  {
+    collection: 'traces',
+    timestamps: true,
+  }
+);
+
+TraceSchema.index({ sessionId: 1, requestId: 1 });
+TraceSchema.index({ traceId: 1 }, { unique: true });
+
+module.exports = models.Trace || model('Trace', TraceSchema);

--- a/ingestBackend/src/repositories/tracesRepository.js
+++ b/ingestBackend/src/repositories/tracesRepository.js
@@ -1,0 +1,52 @@
+const Trace = require('../models/trace');
+
+async function findTracesGroupedByRequestKey(sessionId) {
+  const pipeline = [
+    { $match: { sessionId } },
+    {
+      $lookup: {
+        from: 'requests',
+        localField: 'requestId',
+        foreignField: '_id',
+        as: 'request',
+      },
+    },
+    { $unwind: '$request' },
+    {
+      $group: {
+        _id: '$request.key',
+        request: {
+          $first: {
+            key: '$request.key',
+            durMs: '$request.durMs',
+            status: '$request.status',
+          },
+        },
+        traces: {
+          $push: {
+            id: '$_id',
+            traceId: '$traceId',
+            spans: '$spans',
+            createdAt: '$createdAt',
+            updatedAt: '$updatedAt',
+          },
+        },
+      },
+    },
+    {
+      $project: {
+        _id: 0,
+        key: '$_id',
+        request: 1,
+        traces: 1,
+      },
+    },
+    { $sort: { key: 1 } },
+  ];
+
+  return Trace.aggregate(pipeline);
+}
+
+module.exports = {
+  findTracesGroupedByRequestKey,
+};

--- a/ingestBackend/src/routes/traces.js
+++ b/ingestBackend/src/routes/traces.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const { getTracesForSession } = require('../services/tracesService');
+
+const router = express.Router();
+
+router.get('/sessions/:sessionId/traces', async (req, res, next) => {
+  try {
+    const payload = await getTracesForSession(req.params.sessionId);
+    res.json(payload);
+  } catch (error) {
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/ingestBackend/src/services/tracesService.js
+++ b/ingestBackend/src/services/tracesService.js
@@ -1,0 +1,18 @@
+const { findTracesGroupedByRequestKey } = require('../repositories/tracesRepository');
+
+async function getTracesForSession(sessionId) {
+  if (!sessionId) {
+    throw new Error('A session id is required to query traces.');
+  }
+
+  const results = await findTracesGroupedByRequestKey(sessionId);
+
+  return {
+    sessionId,
+    groups: results,
+  };
+}
+
+module.exports = {
+  getTracesForSession,
+};


### PR DESCRIPTION
## Summary
- create a dedicated `traces` collection that references requests via `requestId`
- expose a grouped trace aggregation endpoint at `GET /sessions/:sessionId/traces`
- document the new collection layout and API in the ingest backend README

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68f3db89195c8327aff56ff332bf4e30