### PR TITLE
feat: store backend traces in separate collection

### DIFF
--- a/docs/backend-trace-batching.md
+++ b/docs/backend-trace-batching.md
@@ -1,0 +1,102 @@
+# Backend trace batching
+
+Backend instrumentation can stream large traces in deterministic batches
+instead of buffering the entire payload in memory. The ingestion endpoint
+accepts one batch per POST request as long as each payload includes a request
+identifier and monotonically increasing `traceBatchIndex` values.
+
+## Streaming from `reproMiddleware`
+
+The snippet below shows one way to adapt the existing Express middleware so it
+flushes batches independently. Each flush sends only the accumulated trace
+events plus metadata for the matching request.
+
+```ts
+const MAX_EVENTS_PER_BATCH = 150;
+
+function reproMiddleware(cfg: { appId: string; appSecret: string; apiBase: string }) {
+    return function handler(req: Request, res: Response, next: NextFunction) {
+        // ... existing header parsing omitted for brevity ...
+
+        type TraceEventPayload = {
+            t: number;
+            type: 'enter' | 'exit';
+            functionType?: string | null;
+            fn?: string;
+            file?: string;
+            line?: number | null;
+            depth?: number;
+            args?: any;
+            returnValue?: any;
+            threw?: boolean;
+            error?: any;
+        };
+
+        const normalizeEvent = (ev: any): TraceEventPayload | null => {
+            // reuse the existing filtering + sanitizing logic from the current middleware
+            // and return `null` for dropped events.
+            return ev as TraceEventPayload;
+        };
+
+        const events: TraceEventPayload[] = [];
+
+        let batchIndex = 0;
+
+        const flush = () => {
+            if (!events.length) return;
+            post(cfg.apiBase, cfg.appId, cfg.appSecret, sid, {
+                entries: [{
+                    actionId: aid,
+                    request: {
+                        rid,
+                        method: req.method,
+                        url,
+                        status: res.statusCode,
+                        durMs: Date.now() - t0,
+                        key,
+                        trace: JSON.stringify(events),
+                        traceBatchIndex: batchIndex++,
+                    },
+                    t: Date.now(),
+                }],
+            });
+            events.length = 0;
+        };
+
+        const maybeFlush = () => {
+            if (events.length >= MAX_EVENTS_PER_BATCH) {
+                flush();
+            }
+        };
+
+        unsubscribe = __TRACER__.tracer.on((ev: any) => {
+            const evt = normalizeEvent(ev);
+            if (!evt) {
+                return;
+            }
+            events.push(evt);
+            maybeFlush();
+        });
+
+        res.on('finish', () => {
+            flush();
+            // ... existing payload handling ...
+        });
+
+        next();
+    };
+}
+```
+
+The service now treats each batch independently, upserting request metadata
+without overriding previously stored fields when a subsequent batch omits them.
+
+## Payload expectations
+
+- Every batch must include a `request.rid` value so it can be attached to the
+  right request document.
+- Provide a numeric `traceBatchIndex` (starting at zero) to preserve ordering.
+- Additional request properties (such as status or duration) are optional after
+  the initial batch. Missing fields no longer clear previous values on the
+  server.
+

--- a/docs/backend-trace-batching.md
+++ b/docs/backend-trace-batching.md
@@ -3,7 +3,9 @@
 Backend instrumentation can stream large traces in deterministic batches
 instead of buffering the entire payload in memory. The ingestion endpoint
 accepts one batch per POST request as long as each payload includes a request
-identifier and monotonically increasing `traceBatchIndex` values.
+identifier and monotonically increasing `traceBatchIndex` values. Trace batches
+can arrive alongside the matching request metadata **or** independently as
+"trace-only" entries when the request data has already been ingested.
 
 ## Streaming from `reproMiddleware`
 
@@ -91,6 +93,42 @@ function reproMiddleware(cfg: { appId: string; appSecret: string; apiBase: strin
 The service now treats each batch independently, upserting request metadata
 without overriding previously stored fields when a subsequent batch omits them.
 
+## Trace-only batches
+
+If your instrumentation emits request metadata separately from the trace
+payloads, post the trace batches on their own. Provide the request identifier at
+the entry level and omit the `request` object entirely:
+
+```json
+{
+  "entries": [
+    {
+      "actionId": "A1",
+      "request": {
+        "rid": "R12",
+        "method": "POST",
+        "url": "/api/apply",
+        "status": 200,
+        "durMs": 140
+      },
+      "t": 1710000000200
+    },
+    {
+      "actionId": "A1",
+      "requestRid": "R12",
+      "trace": "[{\"t\":0,\"type\":\"enter\"}]",
+      "traceBatchIndex": 1,
+      "t": 1710000000205
+    }
+  ]
+}
+```
+
+Each trace-only entry may include either a raw `trace` payload or the
+`traceBatch`/`traceBatches` wrappers shown earlier. The server associates the
+batch with the existing request document using `requestRid` (or the legacy
+`rid`/`traceRid` aliases).
+
 ## Payload expectations
 
 - Every batch must include a `request.rid` value so it can be attached to the
@@ -99,4 +137,6 @@ without overriding previously stored fields when a subsequent batch omits them.
 - Additional request properties (such as status or duration) are optional after
   the initial batch. Missing fields no longer clear previous values on the
   server.
+- Trace batches can be uploaded without a `request` payload by including
+  `requestRid` (or `rid`) at the entry level.
 

--- a/src/docs/dto/sessions.dto.ts
+++ b/src/docs/dto/sessions.dto.ts
@@ -64,6 +64,29 @@ export class BackendDbChangeDto {
 export class BackendEntryDto {
     @ApiProperty({ example: 'A1' }) actionId!: string;
     @ApiPropertyOptional({ type: BackendRequestDto }) request?: BackendRequestDto;
+    @ApiPropertyOptional({ example: 'R12', description: 'Request identifier when sending trace-only batches' })
+    requestRid?: string;
+    @ApiPropertyOptional({
+        description: 'Single trace batch payload (stringified JSON or object)',
+        example: '[{"t":0,"type":"enter"}]',
+    })
+    trace?: any;
+    @ApiPropertyOptional({
+        description: 'Wrapper for a single trace batch with metadata',
+        example: { batchIndex: 0, events: [] },
+        type: 'object',
+    } as any)
+    traceBatch?: Record<string, any>;
+    @ApiPropertyOptional({
+        description: 'Array of trace batches to ingest together',
+        type: 'array',
+        items: { type: 'object' },
+        example: [
+            { batchIndex: 0, events: [] },
+            { batchIndex: 1, events: [] },
+        ],
+    } as any)
+    traceBatches?: Array<Record<string, any>>;
     @ApiPropertyOptional({ type: [BackendDbChangeDto] }) db?: BackendDbChangeDto[];
     @ApiProperty({ example: 1710000000285 }) t!: number;
 }

--- a/src/docs/dto/sessions.dto.ts
+++ b/src/docs/dto/sessions.dto.ts
@@ -61,32 +61,22 @@ export class BackendDbChangeDto {
     @ApiProperty({ example: { status: 'FAILED' }, nullable: true }) after?: Record<string, any> | null;
     @ApiProperty({ example: 'update', enum: ['insert', 'update', 'delete'] }) op!: 'insert'|'update'|'delete';
 }
+export class BackendTraceBatchDto {
+    @ApiProperty({ example: 'R12' }) rid!: string;
+    @ApiProperty({ example: 0 }) index!: number;
+    @ApiPropertyOptional({ example: 3 }) total?: number;
+}
+
 export class BackendEntryDto {
     @ApiProperty({ example: 'A1' }) actionId!: string;
     @ApiPropertyOptional({ type: BackendRequestDto }) request?: BackendRequestDto;
-    @ApiPropertyOptional({ example: 'R12', description: 'Request identifier when sending trace-only batches' })
-    requestRid?: string;
     @ApiPropertyOptional({
-        description: 'Single trace batch payload (stringified JSON or object)',
+        description: 'Trace events captured for the batch (stringified JSON or object)',
         example: '[{"t":0,"type":"enter"}]',
     })
     trace?: any;
-    @ApiPropertyOptional({
-        description: 'Wrapper for a single trace batch with metadata',
-        example: { batchIndex: 0, events: [] },
-        type: 'object',
-    } as any)
-    traceBatch?: Record<string, any>;
-    @ApiPropertyOptional({
-        description: 'Array of trace batches to ingest together',
-        type: 'array',
-        items: { type: 'object' },
-        example: [
-            { batchIndex: 0, events: [] },
-            { batchIndex: 1, events: [] },
-        ],
-    } as any)
-    traceBatches?: Array<Record<string, any>>;
+    @ApiPropertyOptional({ type: BackendTraceBatchDto })
+    traceBatch?: BackendTraceBatchDto;
     @ApiPropertyOptional({ type: [BackendDbChangeDto] }) db?: BackendDbChangeDto[];
     @ApiProperty({ example: 1710000000285 }) t!: number;
 }

--- a/src/sessions/schemas/request.schema.ts
+++ b/src/sessions/schemas/request.schema.ts
@@ -14,7 +14,6 @@ export class RequestEvt {
     @Prop({ type: Object }) headers?: Record<string, any>;
     @Prop() key?: string;                          // normalized endpoint key
     @Prop({ type: SchemaTypes.Mixed }) respBody?: any; // captured JSON response (truncated if needed)
-    @Prop({ type: SchemaTypes.Mixed }) trace?: any; // <-- be explicit and optional
 }
 
 export type RequestEvtDocument = HydratedDocument<RequestEvt>;

--- a/src/sessions/schemas/trace.schema.ts
+++ b/src/sessions/schemas/trace.schema.ts
@@ -10,6 +10,9 @@ export class TraceEvt {
     @Prop({ required: true })
     requestRid!: string;
 
+    @Prop({ required: true })
+    batchIndex!: number;
+
     @Prop({ type: SchemaTypes.ObjectId, ref: RequestEvt.name })
     request?: Types.ObjectId;
 
@@ -20,5 +23,6 @@ export class TraceEvt {
 export type TraceEvtDocument = HydratedDocument<TraceEvt>;
 export const TraceEvtSchema = SchemaFactory.createForClass(TraceEvt);
 
-TraceEvtSchema.index({ sessionId: 1, requestRid: 1 }, { unique: true });
+TraceEvtSchema.index({ sessionId: 1, requestRid: 1, batchIndex: 1 }, { unique: true });
+TraceEvtSchema.index({ sessionId: 1, requestRid: 1 });
 TraceEvtSchema.index({ sessionId: 1 });

--- a/src/sessions/schemas/trace.schema.ts
+++ b/src/sessions/schemas/trace.schema.ts
@@ -1,0 +1,24 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument, SchemaTypes, Types } from 'mongoose';
+import { RequestEvt } from './request.schema';
+
+@Schema({ collection: 'traces' })
+export class TraceEvt {
+    @Prop({ required: true })
+    sessionId!: string;
+
+    @Prop({ required: true })
+    requestRid!: string;
+
+    @Prop({ type: SchemaTypes.ObjectId, ref: RequestEvt.name })
+    request?: Types.ObjectId;
+
+    @Prop({ type: SchemaTypes.Mixed })
+    data?: any;
+}
+
+export type TraceEvtDocument = HydratedDocument<TraceEvt>;
+export const TraceEvtSchema = SchemaFactory.createForClass(TraceEvt);
+
+TraceEvtSchema.index({ sessionId: 1, requestRid: 1 }, { unique: true });
+TraceEvtSchema.index({ sessionId: 1 });

--- a/src/sessions/sessions.controller.ts
+++ b/src/sessions/sessions.controller.ts
@@ -78,6 +78,11 @@ export class SessionsController {
         return this.svc.getTimeline(sessionId);
     }
 
+    @Get('sessions/:sessionId/traces')
+    async getTraces(@Param('sessionId') sessionId: string) {
+        return this.svc.getTracesBySession(sessionId);
+    }
+
     @Get(':sessionId/rrweb/chunk')
     async getChunk(
         @Param('sessionId') sessionId: string,

--- a/src/sessions/sessions.module.ts
+++ b/src/sessions/sessions.module.ts
@@ -10,6 +10,7 @@ import { RrwebChunk, RrwebChunkSchema } from './schemas/rrweb-chunk.schema';
 import { SdkToken, SdkTokenSchema } from '../sdk/schemas/sdk-token.schema';
 import { App, AppSchema } from '../apps/schemas/app.schema';
 import {EmailEvt, EmailEvtSchema} from "./schemas/emails.schema";
+import { TraceEvt, TraceEvtSchema } from './schemas/trace.schema';
 
 @Module({
     imports: [
@@ -21,7 +22,8 @@ import {EmailEvt, EmailEvtSchema} from "./schemas/emails.schema";
             { name: RrwebChunk.name, schema: RrwebChunkSchema },
             { name: SdkToken.name, schema: SdkTokenSchema },
             { name: App.name, schema: AppSchema },
-            { name: EmailEvt.name, schema: EmailEvtSchema }
+            { name: EmailEvt.name, schema: EmailEvtSchema },
+            { name: TraceEvt.name, schema: TraceEvtSchema }
         ]),
     ],
     controllers: [SessionsController],

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -114,6 +114,7 @@ export class SessionsService {
     }
 
     async ingestBackend(sessionId: string, body: any) {
+        console.log('body?.entries --->', JSON.stringify(body?.entries, null, 2))
         const entries = Array.isArray(body?.entries) ? body.entries : [];
 
         for (const e of entries) {
@@ -212,9 +213,9 @@ export class SessionsService {
                     const batchRid = e.traceBatch?.rid ?? resolvedRid;
                     if (batchRid) {
                         let tracePayload: any = e.trace;
-                        if (typeof tracePayload === 'string') {
+                        if (typeof tracePayload !== 'string') {
                             try {
-                                tracePayload = JSON.parse(tracePayload);
+                                tracePayload = JSON.stringify(tracePayload);
                             } catch {
                                 tracePayload = e.trace;
                             }


### PR DESCRIPTION
## Summary
- store backend trace payloads in a dedicated traces collection and reference their request documents
- expose a new GET /v1/sessions/:sessionId/traces endpoint that groups traces by request key and surfaces request metadata
- remove the embedded trace payload from request documents and wire the new schema into the session module

## Testing
- npm test *(fails: jest: not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f3de23cd0883279b3d849c8d8f0d41